### PR TITLE
Add support for new pass manager on LLVM 16

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,9 +1,9 @@
 find_package(LLVM REQUIRED)
 
 add_library(shellvm MODULE
+  SheLLVMPlugin.cpp
   PreparePass.cpp
   PrecheckPass.cpp
-  MergeCallsPass.cpp
   FlattenPass.cpp
   GlobalToStackPass.cpp
   InlineCtorsPass.cpp

--- a/llvm/FlattenPass.cpp
+++ b/llvm/FlattenPass.cpp
@@ -1,149 +1,141 @@
 #include "MergeCallsPass.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Analysis/CallGraph.h"
+#include "llvm/Analysis/InlineCost.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/Analysis/InlineCost.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Local.h"
 
+#include "FlattenPass.h"
+
 using namespace llvm;
 
-namespace {
-struct Flatten : public ModulePass {
-  static char ID;
-  FunctionPass *reg2mem = nullptr;
-  std::vector<Function *> functionsFromMain;
-  Flatten() : ModulePass(ID) {}
-
-  /// Inlines function F into Caller, using MergeCalls to avoid duplication.
-  bool inlineFunction(Function *F, Function *Caller) {
-    if (F->hasFnAttribute(Attribute::NoInline)) {
-      // Function not eligible for inlining. Bail out.
-      return false;
-    }
-
-    if (F->isDeclaration()) {
-      // Function is declared, and not defined. Bail out.
-      return false;
-    }
-
-    // First, run the MergeCalls pass on it:
-    CallInst *CallSite = MergeCalls::mergeCallSites(Caller, F);
-    assert(CallSite && "MergeCalls did not return a unified callsite");
-
-    if (reg2mem == nullptr)
-      reg2mem = llvm::createDemoteRegisterToMemoryPass();
-    reg2mem->runOnFunction(*Caller);
-
-    // Coerce LLVM to inline the function.
-    InlineFunctionInfo IFI;
-    #if LLVM_VERSION_MAJOR >= 11
-        if (!InlineFunction(cast<CallBase>(*CallSite), IFI).isSuccess()) {
-    #else
-        if(!InlineFunction(CallSite, IFI)) {
-    #endif
-            return false;
-    }
-
-    // If F is now completely dead, we can erase it from the module.
-    if (F->isDefTriviallyDead()) {
-      F->eraseFromParent();
-    }
-
-    return true;
-  }
-
-  /// See if Caller calls Callee
-  bool doesNodeCallOther(CallGraphNode *Caller, CallGraphNode *Callee) {
-    for (unsigned i = 0; i < Caller->size(); ++i) {
-      if ((*Caller)[i] == Callee) {
-        return true;
-      }
-    }
-
+/// Inlines function F into Caller, using MergeCalls to avoid duplication.
+bool Flatten::inlineFunction(Function *F, Function *Caller) {
+  if (F->hasFnAttribute(Attribute::NoInline)) {
+    // Function not eligible for inlining. Bail out.
     return false;
   }
 
-  /// Find the CallGraphNode that solely calls CGN, or nullptr if it's not
-  /// called by exactly one other function.
-  CallGraphNode *getSingleCaller(CallGraph &CG, CallGraphNode *CGN) {
-    CallGraphNode *Caller = nullptr;
-    for (auto &CGI : CG) {
-      std::unique_ptr<CallGraphNode> &CGN2 = CGI.second;
+  if (F->isDeclaration()) {
+    // Function is declared, and not defined. Bail out.
+    return false;
+  }
 
-      if (!doesNodeCallOther(CGN2.get(), CGN)) {
-        continue; // Function represented by CGN2 does not call CGN
-      }
+  // First, run the MergeCalls pass on it:
+  CallInst *CallSite = MergeCalls::mergeCallSites(Caller, F);
+  assert(CallSite && "MergeCalls did not return a unified callsite");
 
-      if (CGN2.get() == CG.getExternalCallingNode()) {
-        // CGN2 - a caller of our function - is actually the external calling
-        // node, meaning our function is called externally. It doesn't have a
-        // single, definitive caller.
-        return nullptr;
-      }
+  if (reg2mem == nullptr)
+    reg2mem = llvm::createDemoteRegisterToMemoryPass();
+  reg2mem->runOnFunction(*Caller);
 
-      if (Caller != nullptr) {
-        // We're already called by something else, meaning we have more
-        // than one external caller.
-        return nullptr;
-      }
+  // Coerce LLVM to inline the function.
+  InlineFunctionInfo IFI;
+#if LLVM_VERSION_MAJOR >= 11
+  if (!InlineFunction(cast<CallBase>(*CallSite), IFI).isSuccess()) {
+#else
+  if (!InlineFunction(CallSite, IFI)) {
+#endif
+    return false;
+  }
 
-      // Record our caller, but keep looping to make sure it's the only one.
-      Caller = CGN2.get();
-      assert(Caller->getFunction() && "Caller doesn't represent a function!");
+  // If F is now completely dead, we can erase it from the module.
+  if (F->isDefTriviallyDead()) {
+    F->eraseFromParent();
+  }
+
+  return true;
+}
+
+/// See if Caller calls Callee
+bool Flatten::doesNodeCallOther(CallGraphNode *Caller, CallGraphNode *Callee) {
+  for (unsigned i = 0; i < Caller->size(); ++i) {
+    if ((*Caller)[i] == Callee) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// Find the CallGraphNode that solely calls CGN, or nullptr if it's not
+/// called by exactly one other function.
+CallGraphNode *Flatten::getSingleCaller(CallGraph &CG, CallGraphNode *CGN) {
+  CallGraphNode *Caller = nullptr;
+  for (auto &CGI : CG) {
+    std::unique_ptr<CallGraphNode> &CGN2 = CGI.second;
+
+    if (!doesNodeCallOther(CGN2.get(), CGN)) {
+      continue; // Function represented by CGN2 does not call CGN
     }
 
-    return Caller;
+    if (CGN2.get() == CG.getExternalCallingNode()) {
+      // CGN2 - a caller of our function - is actually the external calling
+      // node, meaning our function is called externally. It doesn't have a
+      // single, definitive caller.
+      return nullptr;
+    }
+
+    if (Caller != nullptr) {
+      // We're already called by something else, meaning we have more
+      // than one external caller.
+      return nullptr;
+    }
+
+    // Record our caller, but keep looping to make sure it's the only one.
+    Caller = CGN2.get();
+    assert(Caller->getFunction() && "Caller doesn't represent a function!");
   }
 
-  bool runOnModule(Module &M) override {
-    bool ModifiedAny = false;
-    bool ModifiedOne = false;
-    SmallSetVector<Function *, 4> ModifiedFunctions;
+  return Caller;
+}
 
-    // We keep running, inlining functions into other functions, until there's
-    // no work left to do.
-    do {
-      ModifiedOne = false;
+llvm::PreservedAnalyses Flatten::run(Module &M, ModuleAnalysisManager &AM) {
+  bool ModifiedAny = false;
+  bool ModifiedOne = false;
+  SmallSetVector<Function *, 4> ModifiedFunctions;
 
-      // Build the call graph of the entire module.
-      CallGraph CG(M);
+  // We keep running, inlining functions into other functions, until there's
+  // no work left to do.
+  do {
+    ModifiedOne = false;
 
-      for (Function &F : M.functions()) {
-        CallGraphNode *CGN = CG[&F];
-        CallGraphNode *Caller = getSingleCaller(CG, CGN);
+    // Build the call graph of the entire module.
+    CallGraph CG(M);
 
-        if (Caller == nullptr) {
-          continue; // We need a function with a single caller function
-        }
+    for (Function &F : M.functions()) {
+      CallGraphNode *CGN = CG[&F];
+      CallGraphNode *Caller = getSingleCaller(CG, CGN);
 
-        if (inlineFunction(&F, Caller->getFunction())) {
-          // Keep track of functions that need reg2mem
-          ModifiedFunctions.insert(Caller->getFunction());
-          ModifiedFunctions.remove(&F);
-
-          // Mark the module as modified and start over
-          ModifiedOne = true;
-          ModifiedAny = true;
-          break;
-        }
+      if (Caller == nullptr) {
+        continue; // We need a function with a single caller function
       }
 
-    } while (ModifiedOne);
+      if (inlineFunction(&F, Caller->getFunction())) {
+        // Keep track of functions that need reg2mem
+        ModifiedFunctions.insert(Caller->getFunction());
+        ModifiedFunctions.remove(&F);
 
-    return ModifiedAny;
+        // Mark the module as modified and start over
+        ModifiedOne = true;
+        ModifiedAny = true;
+        break;
+      }
+    }
+
+  } while (ModifiedOne);
+
+  if (ModifiedAny) {
+    return llvm::PreservedAnalyses::none();
   }
-}; // end of struct Flatten
-} // end of anonymous namespace
-
-char Flatten::ID = 0;
-static RegisterPass<Flatten> X("shellvm-flatten", "Flatten Functions Pass",
-                               false /* Only looks at CFG */,
-                               false /* Analysis Pass */);
+  return llvm::PreservedAnalyses::all();
+}

--- a/llvm/FlattenPass.h
+++ b/llvm/FlattenPass.h
@@ -1,0 +1,25 @@
+#ifndef FLATTEN_PASS_H
+#define FLATTEN_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct Flatten : PassInfoMixin<Flatten> {
+  FunctionPass *reg2mem = nullptr;
+  std::vector<Function *> functionsFromMain;
+
+  /// Inlines function F into Caller, using MergeCalls to avoid duplication.
+  bool inlineFunction(Function *F, Function *Caller);
+
+  /// See if Caller calls Callee
+  bool doesNodeCallOther(CallGraphNode *Caller, CallGraphNode *Callee);
+
+  /// Find the CallGraphNode that solely calls CGN, or nullptr if it's not
+  /// called by exactly one other function.
+  CallGraphNode *getSingleCaller(CallGraph &CG, CallGraphNode *CGN);
+
+  llvm::PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+}; // end of struct Flatten
+
+#endif

--- a/llvm/GlobalToStackPass.cpp
+++ b/llvm/GlobalToStackPass.cpp
@@ -133,7 +133,7 @@ struct GlobalToStack : public ModulePass {
       } else if (isa<ConstantExpr>(C2) ||
                  (isa<GlobalVariable>(C2) &&
                   Vars.count(cast<GlobalVariable>(C2)))) {
-        GetElementPtrInst *GEP = GetElementPtrInst::CreateInBounds(Ptr, Idx);
+        GetElementPtrInst *GEP = GetElementPtrInst::CreateInBounds(C.getType(), Ptr, Idx);
         GEP->insertAfter(After);
 
         ToUndefine.insert(C2);

--- a/llvm/GlobalToStackPass.h
+++ b/llvm/GlobalToStackPass.h
@@ -1,0 +1,24 @@
+#ifndef GLOBAL_TO_STACK_PASS_H
+#define GLOBAL_TO_STACK_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct GlobalToStack : PassInfoMixin<GlobalToStack> {
+
+  bool shouldInline(GlobalVariable &G);
+
+  void disaggregateVars(Instruction *After, Value *Ptr,
+                        SmallVectorImpl<Value *> &Idx, ConstantAggregate &C,
+                        SmallSetVector<GlobalVariable *, 4> &Vars);
+
+  void extractValuesFromStore(StoreInst *inst,
+                              SmallSetVector<GlobalVariable *, 4> &Vars);
+
+  void inlineGlobals(Function *F, SmallSetVector<GlobalVariable *, 4> &Vars);
+
+  llvm::PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+}; // end of struct GlobalToStack
+
+#endif

--- a/llvm/InlineCtorsPass.cpp
+++ b/llvm/InlineCtorsPass.cpp
@@ -4,102 +4,91 @@
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 
+#include "InlineCtorsPass.h"
+
 using namespace llvm;
 
-namespace {
-struct InlineCtorsPass : public FunctionPass {
-  static char ID;
+void InlineCtorsPass::getFunctions(GlobalVariable *Tors,
+                                   SmallVectorImpl<FunctionPair> &Vec) {
+  if (!Tors) {
+    return;
+  }
+  ConstantArray *A = cast<ConstantArray>(Tors->getOperand(0));
 
-  typedef std::pair<Function *, uint64_t> FunctionPair;
-
-  InlineCtorsPass() : FunctionPass(ID) {}
-
-  void getFunctions(GlobalVariable *Tors, SmallVectorImpl<FunctionPair> &Vec) {
-    if (!Tors) {
-      return;
+  for (int I = 0, E = A->getNumOperands(); I < E; ++I) {
+    ConstantStruct *S = cast<ConstantStruct>(A->getOperand(I));
+    if (Function *Fn = dyn_cast<Function>(S->getOperand(1))) {
+      Vec.push_back(std::make_pair(
+          Fn, cast<ConstantInt>(S->getOperand(0))->getZExtValue()));
     }
-    ConstantArray *A = cast<ConstantArray>(Tors->getOperand(0));
+  }
+}
 
-    for (int I = 0, E = A->getNumOperands(); I < E; ++I) {
-      ConstantStruct *S = cast<ConstantStruct>(A->getOperand(I));
-      if (Function *Fn = dyn_cast<Function>(S->getOperand(1))) {
-        Vec.push_back(std::make_pair(
-            Fn, cast<ConstantInt>(S->getOperand(0))->getZExtValue()));
-      }
+llvm::PreservedAnalyses InlineCtorsPass::run(Function &F,
+                                             FunctionAnalysisManager &FM) {
+  if (!F.hasFnAttribute("shellvm-main")) {
+
+    return llvm::PreservedAnalyses::all();
+  }
+
+  GlobalVariable *GlobalCtors =
+      F.getParent()->getNamedGlobal("llvm.global_ctors");
+  GlobalVariable *GlobalDtors =
+      F.getParent()->getNamedGlobal("llvm.global_dtors");
+  if (!GlobalCtors && !GlobalDtors) {
+    return llvm::PreservedAnalyses::all();
+  }
+
+  SmallVector<FunctionPair, 4> Ctors;
+  getFunctions(GlobalCtors, Ctors);
+  SmallVector<FunctionPair, 4> Dtors;
+  getFunctions(GlobalDtors, Dtors);
+
+  // Sort constructors in ascending order of priority
+  std::sort(Ctors.begin(), Ctors.end(),
+            [](const FunctionPair &A, const FunctionPair &B) -> bool {
+              return A.second > B.second;
+            });
+
+  // Sort destructors in descending order of priority
+  std::sort(Ctors.begin(), Ctors.end(),
+            [](const FunctionPair &A, const FunctionPair &B) -> bool {
+              return A.second < B.second;
+            });
+
+  {
+    BasicBlock *BBEntry = &F.getEntryBlock();
+    BasicBlock::iterator I = BBEntry->begin();
+    // Place calls to constructors after alloca
+    while (isa<AllocaInst>(I))
+      ++I;
+
+    for (auto &KV : Ctors) {
+      CallInst::Create(KV.first, ArrayRef<Value *>(), "", &*I);
     }
   }
 
-  bool runOnFunction(Function &F) override {
-    if (!F.hasFnAttribute("shellvm-main")) {
-      return false;
+  // Search for ret instructions
+  for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
+    if (!isa<ReturnInst>(*I)) {
+      continue;
     }
 
-    GlobalVariable *GlobalCtors =
-        F.getParent()->getNamedGlobal("llvm.global_ctors");
-    GlobalVariable *GlobalDtors =
-        F.getParent()->getNamedGlobal("llvm.global_dtors");
-    if (!GlobalCtors && !GlobalDtors) {
-      return false;
+    for (auto &KV : Dtors) {
+      CallInst::Create(KV.first, ArrayRef<Value *>(), "", &*I);
     }
-
-    SmallVector<FunctionPair, 4> Ctors;
-    getFunctions(GlobalCtors, Ctors);
-    SmallVector<FunctionPair, 4> Dtors;
-    getFunctions(GlobalDtors, Dtors);
-
-    // Sort constructors in ascending order of priority
-    std::sort(Ctors.begin(), Ctors.end(),
-              [](const FunctionPair &A, const FunctionPair &B) -> bool {
-                return A.second > B.second;
-              });
-
-    // Sort destructors in descending order of priority
-    std::sort(Ctors.begin(), Ctors.end(),
-              [](const FunctionPair &A, const FunctionPair &B) -> bool {
-                return A.second < B.second;
-              });
-
-    {
-      BasicBlock *BBEntry = &F.getEntryBlock();
-      BasicBlock::iterator I = BBEntry->begin();
-      // Place calls to constructors after alloca
-      while (isa<AllocaInst>(I))
-        ++I;
-
-      for (auto &KV : Ctors) {
-        CallInst::Create(KV.first, ArrayRef<Value *>(), "", &*I);
-      }
-    }
-
-    // Search for ret instructions
-    for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
-      if (!isa<ReturnInst>(*I)) {
-        continue;
-      }
-
-      for (auto &KV : Dtors) {
-        CallInst::Create(KV.first, ArrayRef<Value *>(), "", &*I);
-      }
-    }
-
-    // Delete llvm.global_ctors and llvm.global_dtors to prevent duplicate calls
-    if (GlobalCtors)
-      GlobalCtors->removeFromParent();
-    if (GlobalDtors)
-      GlobalDtors->removeFromParent();
-
-    return true;
   }
-}; // end of struct InlineCtorsPass
-} // end of anonymous namespace
 
-char InlineCtorsPass::ID = 0;
+  // Delete llvm.global_ctors and llvm.global_dtors to prevent duplicate calls
+  if (GlobalCtors)
+    GlobalCtors->removeFromParent();
+  if (GlobalDtors)
+    GlobalDtors->removeFromParent();
 
-static RegisterPass<InlineCtorsPass>
-    X("shellvm-inlinectors",
-      "Moves global constructors and destructors to the shellvm-main function",
-      false /* Only looks at CFG */, false /* Analysis Pass */);
+  return llvm::PreservedAnalyses::none();
+}

--- a/llvm/InlineCtorsPass.h
+++ b/llvm/InlineCtorsPass.h
@@ -1,0 +1,16 @@
+#ifndef INLINE_CTORS_PASS_H
+#define INLINE_CTORS_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct InlineCtorsPass : PassInfoMixin<InlineCtorsPass> {
+  typedef std::pair<Function *, uint64_t> FunctionPair;
+
+  void getFunctions(GlobalVariable *Tors, SmallVectorImpl<FunctionPair> &Vec);
+
+  llvm::PreservedAnalyses run(Function &F, FunctionAnalysisManager &FM);
+};
+
+#endif

--- a/llvm/MergeCallsPass.cpp
+++ b/llvm/MergeCallsPass.cpp
@@ -1,8 +1,0 @@
-#include "MergeCallsPass.h"
-#include "llvm/Pass.h"
-
-using namespace llvm;
-
-static RegisterPass<MergeCalls> X("mergecalls", "Merge Calls Pass",
-                                  false /* Only looks at CFG */,
-                                  false /* Analysis Pass */);

--- a/llvm/MergeCallsPass.h
+++ b/llvm/MergeCallsPass.h
@@ -25,7 +25,7 @@ struct MergeCalls : public FunctionPass {
   /// Get a/the BasicBlock containing an unreachable instruction.
   static BasicBlock *getUnreachableBlock(Function *F) {
     for (BasicBlock &BB : *F) {
-      if (BB.getInstList().size() == 1) {
+      if (BB.size() == 1) {
         // Single-instruction block, let's see if it only consists of a
         // unreachable instruction.
         const Instruction *instr = BB.getFirstNonPHI();

--- a/llvm/PostcheckPass.cpp
+++ b/llvm/PostcheckPass.cpp
@@ -1,97 +1,87 @@
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include "PostcheckPass.h"
 
 using namespace std;
 using namespace llvm;
 
-namespace {
-struct Postcheck : public ModulePass {
-  static char ID;
-  Postcheck() : ModulePass(ID) {}
-
-  bool dfsTraverse(CallGraphNode *node) {
-    for (auto &KV : *node) {
-      CallGraphNode *child = KV.second;
-      if (child == nullptr) {
-        return true;
-      }
-
-      if (child->getFunction() && !child->getFunction()->isIntrinsic()) {
-        return false;
-      }
-
-      if (!dfsTraverse(child)) {
-        return false;
-      }
+bool Postcheck::dfsTraverse(CallGraphNode *node) {
+  for (auto &KV : *node) {
+    CallGraphNode *child = KV.second;
+    if (child == nullptr) {
+      return true;
     }
 
-    return true;
+    if (child->getFunction() && !child->getFunction()->isIntrinsic()) {
+      return false;
+    }
+
+    if (!dfsTraverse(child)) {
+      return false;
+    }
   }
 
-  bool runOnModule(Module &M) override {
-    // Check 1: Make sure we only have a single function, with the attribute
-    // shellvm-main.
-    Function *mainFunc = nullptr;
+  return true;
+}
 
-    for (Function &f : M.functions()) {
-      if (f.isIntrinsic()) {
-        continue;
-      }
+llvm::PreservedAnalyses Postcheck::run(Module &M, ModuleAnalysisManager &AM) {
+  // Check 1: Make sure we only have a single function, with the attribute
+  // shellvm-main.
+  Function *mainFunc = nullptr;
 
-      if (mainFunc) {
-        report_fatal_error("More than one function in module!");
-        mainFunc = nullptr;
-        continue;
-      }
-
-      mainFunc = &f;
+  for (Function &f : M.functions()) {
+    if (f.isIntrinsic()) {
+      continue;
     }
 
-    if (!mainFunc) {
-      report_fatal_error("No functions found in module!");
-    }
-
-    if (mainFunc && !mainFunc->hasFnAttribute("shellvm-main")) {
-      report_fatal_error("SheLLVM main function " + mainFunc->getName() +
-                         " has no shellvm-main attribute!");
-    }
-
-    // Check 2: Make sure there are no globals.
-    for (GlobalVariable &global : M.getGlobalList()) {
-      if (!global.getSection().equals("llvm.metadata")) {
-        report_fatal_error("Module has global variables!");
-      }
-    }
-
-    // Check 3: No switch instructions allowed in function body.
     if (mainFunc) {
-      for (BasicBlock &BB : *mainFunc) {
-        for (Instruction &I : BB) {
-          if (isa<SwitchInst>(I)) {
-            report_fatal_error(
-                "Switch instruction found within main function.");
-          }
+      report_fatal_error("More than one function in module!");
+      mainFunc = nullptr;
+      continue;
+    }
+
+    mainFunc = &f;
+  }
+
+  if (!mainFunc) {
+    report_fatal_error("No functions found in module!");
+  }
+
+  if (mainFunc && !mainFunc->hasFnAttribute("shellvm-main")) {
+    report_fatal_error("SheLLVM main function " + mainFunc->getName() +
+                       " has no shellvm-main attribute!");
+  }
+
+  // Check 2: Make sure there are no globals.
+  for (GlobalVariable &global : M.getGlobalList()) {
+    if (!global.getSection().equals("llvm.metadata")) {
+      report_fatal_error("Module has global variables!");
+    }
+  }
+
+  // Check 3: No switch instructions allowed in function body.
+  if (mainFunc) {
+    for (BasicBlock &BB : *mainFunc) {
+      for (Instruction &I : BB) {
+        if (isa<SwitchInst>(I)) {
+          report_fatal_error("Switch instruction found within main function.");
         }
       }
-
-      // Check 4: No external calls (that aren't LLVM intrinsics).
-      CallGraph *cg = new CallGraph(M);
-      CallGraphNode *cgn = cg->operator[](mainFunc);
-      if (!dfsTraverse(cgn)) {
-        report_fatal_error(
-            "Non-intrinsic external call found within main function!");
-      }
     }
 
-    return false;
+    // Check 4: No external calls (that aren't LLVM intrinsics).
+    CallGraph *cg = new CallGraph(M);
+    CallGraphNode *cgn = cg->operator[](mainFunc);
+    if (!dfsTraverse(cgn)) {
+      report_fatal_error(
+          "Non-intrinsic external call found within main function!");
+    }
   }
-}; // end of struct Postcheck
-} // end of anonymous namespace
 
-char Postcheck::ID = 0;
-static RegisterPass<Postcheck> X("shellvm-postcheck", "Postcheck Pass",
-                                 false /* Only looks at CFG */,
-                                 false /* Analysis Pass */);
+  return llvm::PreservedAnalyses::all();
+}

--- a/llvm/PostcheckPass.h
+++ b/llvm/PostcheckPass.h
@@ -1,0 +1,14 @@
+#ifndef POSTCHECK_PASS_H
+#define POSTCHECK_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct Postcheck : PassInfoMixin<Postcheck> {
+  bool dfsTraverse(CallGraphNode *node);
+
+  llvm::PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+}; // end of struct Postcheck
+
+#endif

--- a/llvm/PrecheckPass.cpp
+++ b/llvm/PrecheckPass.cpp
@@ -1,34 +1,26 @@
 #include "llvm/IR/Function.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include "PrecheckPass.h"
 
 using namespace std;
 using namespace llvm;
 
-namespace {
-struct Precheck : public FunctionPass {
-  static char ID;
-  Precheck() : FunctionPass(ID) {}
-
-  bool runOnFunction(Function &F) override {
-    if (!F.hasFnAttribute("shellvm-main")) {
-      if (F.getUnnamedAddr() != GlobalValue::UnnamedAddr::None) {
-        report_fatal_error("Function " + F.getName() +
-                           " is not marked as unnamed_addr!");
-      }
-    } else {
-      if (F.getUnnamedAddr() != GlobalValue::UnnamedAddr::Local) {
-        report_fatal_error("SheLLVM main function " + F.getName() +
-                           " is not marked as local_unnamed_addr!");
-      }
+llvm::PreservedAnalyses Precheck::run(Function &F,
+                                      FunctionAnalysisManager &FM) {
+  if (!F.hasFnAttribute("shellvm-main")) {
+    if (F.getUnnamedAddr() != GlobalValue::UnnamedAddr::None) {
+      report_fatal_error("Function " + F.getName() +
+                         " is not marked as unnamed_addr!");
     }
-
-    return false;
+  } else {
+    if (F.getUnnamedAddr() != GlobalValue::UnnamedAddr::Local) {
+      report_fatal_error("SheLLVM main function " + F.getName() +
+                         " is not marked as local_unnamed_addr!");
+    }
   }
-}; // end of struct Precheck
-} // end of anonymous namespace
 
-char Precheck::ID = 0;
-static RegisterPass<Precheck> X("shellvm-precheck", "Precheck Pass",
-                                false /* Only looks at CFG */,
-                                false /* Analysis Pass */);
+  return PreservedAnalyses::all();
+}

--- a/llvm/PrecheckPass.h
+++ b/llvm/PrecheckPass.h
@@ -1,0 +1,12 @@
+#ifndef PRECHECK_PASS_H
+#define PRECHECK_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct Precheck : PassInfoMixin<Precheck> {
+  llvm::PreservedAnalyses run(Function &F, FunctionAnalysisManager &FM);
+};
+
+#endif

--- a/llvm/PreparePass.cpp
+++ b/llvm/PreparePass.cpp
@@ -36,10 +36,10 @@ struct PreparePass : public ModulePass {
     for (int I = 0, E = A->getNumOperands(); I < E; ++I) {
       auto D = cast<ConstantStruct>(A->getOperand(I));
 
-      if (auto Fn = dyn_cast<Function>(D->getOperand(0)->getOperand(0))) {
+      if (auto Fn = dyn_cast<Function>(D->getOperand(0))) {
         auto Annotation =
             cast<ConstantDataArray>(
-                cast<GlobalVariable>(D->getOperand(1)->getOperand(0))
+                cast<GlobalVariable>(D->getOperand(1))
                     ->getOperand(0))
                 ->getAsCString();
 

--- a/llvm/PreparePass.cpp
+++ b/llvm/PreparePass.cpp
@@ -1,74 +1,65 @@
+#include "PreparePass.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 
 using namespace llvm;
 
-namespace {
-
 // This pass makes sure exactly one function is marked as the main
 // function (via the __attribute__((annotate("shellvm-main"))) annotation).
 // It removes this annotation, replaces it with an LLVM attribute, and marks
 // all other functions in the module as private.
-struct PreparePass : public ModulePass {
-  static char ID;
-  PreparePass() : ModulePass(ID) {}
+bool PreparePass::mustPreserve(const GlobalValue &value) {
+  if (!isa<Function>(value))
+    return false;
 
-  bool mustPreserve(const GlobalValue &value) {
-    if (!isa<Function>(value))
-      return false;
+  const Function &fn = cast<Function>(value);
+  return (!fn.isDeclaration() && fn.hasFnAttribute("shellvm-main"));
+}
 
-    const Function &fn = cast<Function>(value);
-    return (!fn.isDeclaration() && fn.hasFnAttribute("shellvm-main"));
+llvm::PreservedAnalyses PreparePass::run(Module &M, ModuleAnalysisManager &AM) {
+  auto GlobalMains = M.getNamedGlobal("llvm.global.annotations");
+  if (!GlobalMains) {
+    report_fatal_error("No functions have been annotated with shellvm-main");
   }
 
-  bool runOnModule(Module &M) override {
-    auto GlobalMains = M.getNamedGlobal("llvm.global.annotations");
-    if (!GlobalMains) {
-      report_fatal_error("No functions have been annotated with shellvm-main");
-    }
+  bool FoundAnnotation = false;
+  ConstantArray *A = cast<ConstantArray>(GlobalMains->getOperand(0));
+  for (int I = 0, E = A->getNumOperands(); I < E; ++I) {
+    auto D = cast<ConstantStruct>(A->getOperand(I));
 
-    bool FoundAnnotation = false;
-    ConstantArray *A = cast<ConstantArray>(GlobalMains->getOperand(0));
-    for (int I = 0, E = A->getNumOperands(); I < E; ++I) {
-      auto D = cast<ConstantStruct>(A->getOperand(I));
+    if (auto Fn = dyn_cast<Function>(D->getOperand(0))) {
+      auto Annotation =
+          cast<ConstantDataArray>(
+              cast<GlobalVariable>(D->getOperand(1))->getOperand(0))
+              ->getAsCString();
 
-      if (auto Fn = dyn_cast<Function>(D->getOperand(0))) {
-        auto Annotation =
-            cast<ConstantDataArray>(
-                cast<GlobalVariable>(D->getOperand(1))
-                    ->getOperand(0))
-                ->getAsCString();
-
-        if (Annotation == "shellvm-main") {
-          if (FoundAnnotation) {
-            report_fatal_error("More than one function has been annotated "
-                               "with shellvm-main");
-          }
-          Fn->addFnAttr(Annotation);
-          FoundAnnotation = true;
-          // Continue searching for duplicate annotations
+      if (Annotation == "shellvm-main") {
+        if (FoundAnnotation) {
+          report_fatal_error("More than one function has been annotated "
+                             "with shellvm-main");
         }
+        Fn->addFnAttr(Annotation);
+        FoundAnnotation = true;
+        // Continue searching for duplicate annotations
       }
     }
-
-    if (!FoundAnnotation) {
-      report_fatal_error("No functions have been annotated with shellvm-main");
-    }
-
-    llvm::internalizeModule(
-        M, std::bind(&PreparePass::mustPreserve, this, std::placeholders::_1));
-    return true;
   }
 
-}; // end of struct PreparePass
-} // end of anonymous namespace
+  if (!FoundAnnotation) {
+    report_fatal_error("No functions have been annotated with shellvm-main");
+  }
 
-char PreparePass::ID = 0;
+  llvm::internalizeModule(
+      M, std::bind(&PreparePass::mustPreserve, this, std::placeholders::_1));
 
-static RegisterPass<PreparePass> X("shellvm-prepare", "SheLLVM Prepare Pass",
-                                   false /* Only looks at CFG */,
-                                   false /* Analysis Pass */);
+  return llvm::PreservedAnalyses::none();
+}
+
+// static RegisterPass<PreparePass> X("shellvm-prepare", "SheLLVM Prepare Pass",
+//                                    false /* Only looks at CFG */,
+//                                    false /* Analysis Pass */);

--- a/llvm/PreparePass.h
+++ b/llvm/PreparePass.h
@@ -1,0 +1,13 @@
+#ifndef PREPARE_PASS_H
+#define PREPARE_PASS_H
+
+#include "llvm/IR/PassManager.h"
+
+using namespace llvm;
+
+struct PreparePass : PassInfoMixin<PreparePass> {
+  bool mustPreserve(const GlobalValue &value);
+  llvm::PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+#endif

--- a/llvm/SheLLVMPlugin.cpp
+++ b/llvm/SheLLVMPlugin.cpp
@@ -1,0 +1,59 @@
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+
+#include "FlattenPass.h"
+#include "GlobalToStackPass.h"
+#include "InlineCtorsPass.h"
+#include "MergeCallsPass.h"
+#include "PostcheckPass.h"
+#include "PrecheckPass.h"
+#include "PreparePass.h"
+
+using namespace llvm;
+
+llvm::PassPluginLibraryInfo getSheLLVMPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "SheLLVM", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            // Register module passes
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, llvm::ModulePassManager &PM,
+                   ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "shellvm-prepare") {
+                    PM.addPass(PreparePass());
+                    return true;
+                  } else if (Name == "shellvm-postcheck") {
+                    PM.addPass(Postcheck());
+                    return true;
+                  } else if (Name == "shellvm-flatten") {
+                    PM.addPass(Flatten());
+                    return true;
+                  } else if (Name == "shellvm-global2stack") {
+                    PM.addPass(GlobalToStack());
+                    return true;
+                  }
+                  return false;
+                });
+
+            // Register function passes
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, llvm::FunctionPassManager &PM,
+                   ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                  if (Name == "shellvm-precheck") {
+                    PM.addPass(Precheck());
+                    return true;
+                  } else if (Name == "mergecalls") {
+                    PM.addPass(MergeCalls());
+                    return true;
+                  } else if (Name == "shellvm-inlinectors") {
+                    PM.addPass(InlineCtorsPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getSheLLVMPluginInfo();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,11 +2,8 @@ function(add_test_case name file)
   add_custom_target(${name} ALL
     COMMAND ${CMAKE_C_COMPILER} -O1 -Xclang -disable-llvm-passes
       -c -emit-llvm -o ${name}.bc ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-    COMMAND opt -load=$<TARGET_FILE:shellvm>
-      -enable-new-pm=0
-      -shellvm-prepare -shellvm-flatten -shellvm-global2stack
-      -mem2reg -globaldce -lowerswitch
-      -shellvm-postcheck
+    COMMAND opt --load-pass-plugin=$<TARGET_FILE:shellvm>
+      --passes=shellvm-prepare,shellvm-flatten,shellvm-global2stack,mem2reg,globaldce,lowerswitch,shellvm-postcheck
       -o ${name}-out.bc ${name}.bc
     BYPRODUCTS ${name}.bc ${name}-out.bc
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ function(add_test_case name file)
     COMMAND ${CMAKE_C_COMPILER} -O1 -Xclang -disable-llvm-passes
       -c -emit-llvm -o ${name}.bc ${CMAKE_CURRENT_SOURCE_DIR}/${file}
     COMMAND opt -load=$<TARGET_FILE:shellvm>
+      -enable-new-pm=0
       -shellvm-prepare -shellvm-flatten -shellvm-global2stack
       -mem2reg -globaldce -lowerswitch
       -shellvm-postcheck


### PR DESCRIPTION
This PR ports all of the SheLLVM passes over to the new plugin format used by the new LLVM pass manager, and additionally updates the passes to be functional on LLVM 16. Support for the old pass manager (which is non-default as of LLVM 12) has been removed.

I've not yet tested this on LLVM versions other than 16. Testing will need to be performed on any older version we still want to support.